### PR TITLE
Fix OneDrive project path helper aliases

### DIFF
--- a/ProjektManager/Helpers/ProjektPfadHelper.cs
+++ b/ProjektManager/Helpers/ProjektPfadHelper.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System;
 using System.IO;
 
-namespace ProjektManager.Helpers // DİKKAT: BU namespace senin projenin adıyla aynı olmalı!
+namespace ProjektManager.Helpers
 {
     public static class ProjektPfadHelper
     {
@@ -23,8 +18,16 @@ namespace ProjektManager.Helpers // DİKKAT: BU namespace senin projenin adıyla
         public static string LWLProjektOrdner => Path.Combine(BaseOrdner, "LWL_Projekte");
         public static string LWLIndexDatei => Path.Combine(LWLProjektOrdner, "lwl_projekte_index.json");
 
+        // Eski property isimleriyle uyumluluk
+        public static string LST_Projekte_Ordner => LSTProjektOrdner;
+        public static string LST_IndexDatei => LSTIndexDatei;
+        public static string LWL_Projekte_Ordner => LWLProjektOrdner;
+        public static string LWL_IndexDatei => LWLIndexDatei;
+
         public static void StelleVerzeichnisseSicher(string unterordner)
         {
+            Directory.CreateDirectory(BaseOrdner);
+
             string pfad = Path.Combine(BaseOrdner, unterordner);
             if (!Directory.Exists(pfad))
                 Directory.CreateDirectory(pfad);


### PR DESCRIPTION
## Summary
- simplify the OneDrive base path helper to use the current user's profile directory automatically
- restore legacy property names so existing code can resolve LST and LWL folders and index files
- ensure the base ProjektManagerProgramm folder is created before subdirectories and indexes

## Testing
- dotnet build ProjektManager.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcb440ae483279ab506a4cee3ad24