### PR TITLE
Persist projects in OneDrive directory

### DIFF
--- a/ProjektManager/Data/ProjektSpeicher.cs
+++ b/ProjektManager/Data/ProjektSpeicher.cs
@@ -1,30 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 using ProjektManager.Models;
 using System.IO;
+using ProjektManager.Helpers;
 
 namespace ProjektManager.Data
 {
     public static class ProjektSpeicher
     {
-        private static readonly string SpeicherPfad = "projekte.json";
+        private static string SpeicherPfad => ProjektPfadHelper.ProjekteDateiPfad;
 
         public static void Speichern(List<Projekt> projekte)
         {
+            var pfad = SpeicherPfad;
+            var verzeichnis = Path.GetDirectoryName(pfad);
+            if (!string.IsNullOrEmpty(verzeichnis))
+            {
+                Directory.CreateDirectory(verzeichnis);
+            }
+
             var json = JsonSerializer.Serialize(projekte, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(SpeicherPfad, json);
+            File.WriteAllText(pfad, json);
         }
 
         public static List<Projekt> Laden()
         {
-            if (!File.Exists(SpeicherPfad))
+            var pfad = SpeicherPfad;
+
+            if (!File.Exists(pfad))
                 return new List<Projekt>();
 
-            var json = File.ReadAllText(SpeicherPfad);
+            var json = File.ReadAllText(pfad);
             return JsonSerializer.Deserialize<List<Projekt>>(json) ?? new List<Projekt>();
         }
     }

--- a/ProjektManager/Helpers/ProjektPfadHelper.cs
+++ b/ProjektManager/Helpers/ProjektPfadHelper.cs
@@ -10,6 +10,15 @@ namespace ProjektManager.Helpers
             "OneDrive - Klefenz GmbH",
             "ProjektManagerProgramm");
 
+        public static string ProjekteDateiPfad
+        {
+            get
+            {
+                Directory.CreateDirectory(BaseOrdner);
+                return Path.Combine(BaseOrdner, "projekte.json");
+            }
+        }
+
         // LST klasör ve index
         public static string LSTProjektOrdner => Path.Combine(BaseOrdner, "LST_Projekte");
         public static string LSTIndexDatei => Path.Combine(LSTProjektOrdner, "lst_projekte_index.json");


### PR DESCRIPTION
## Summary
- expose a helper property for the OneDrive-backed projektes.json path and ensure the base folder exists
- update ProjektSpeicher to use the helper path and create the directory before reading or writing

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd026c2a883279d693c612b8c993e