### PR TITLE
Alias System.IO.Path usage in overview page

### DIFF
--- a/ProjektManager/Views/ProjektUebersichtPage.xaml.cs
+++ b/ProjektManager/Views/ProjektUebersichtPage.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 using Newtonsoft.Json;
 using ProjektManager.Helpers;
 using System.IO;
+using IOPath = System.IO.Path;
 
 
 
@@ -156,7 +157,7 @@ namespace ProjektManager.Views
 
             foreach (var name in eindeutigeNamen)
             {
-                string jsonPfad = Path.Combine(ProjektPfadHelper.LST_Projekte_Ordner, name + ".json");
+                string jsonPfad = IOPath.Combine(ProjektPfadHelper.LST_Projekte_Ordner, name + ".json");
                 List<LSTKabel>? kabel = null;
 
                 if (File.Exists(jsonPfad))
@@ -231,7 +232,7 @@ namespace ProjektManager.Views
 
             foreach (var name in eindeutigeNamen)
             {
-                string pfad = Path.Combine(ProjektPfadHelper.LWLProjektOrdner, name + ".json");
+                string pfad = IOPath.Combine(ProjektPfadHelper.LWLProjektOrdner, name + ".json");
                 Projekt? projekt = null;
 
                 if (File.Exists(pfad))


### PR DESCRIPTION
## Summary
- add an alias for System.IO.Path in ProjektUebersichtPage to prevent conflicts with System.Windows.Shapes.Path
- update JSON path construction to use the alias

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbde3d0c9c8327a01eb1f893955b19